### PR TITLE
Fix malayalam words going out of screen on mobile

### DIFF
--- a/src/components/QuizComponent.re
+++ b/src/components/QuizComponent.re
@@ -77,7 +77,7 @@ let showQuestion = (quiz, question, setState, state, totalQuestions) => {
         </p>
         <p> {quiz |> Quiz.title |> str} </p>
       </div>
-      <h1 className="font-bold pt-1 pb-2 leading-tight">
+      <h1 className="font-bold pt-1 pb-2 leading-tight break-words">
         {question |> Question.title |> str}
       </h1>
       <div>


### PR DESCRIPTION
**Before:**
![Words extending out of screen](https://user-images.githubusercontent.com/8883368/76711972-621c3000-673a-11ea-8b08-ae2e7ebe1532.png)

**After:**
![Words split to next line](https://user-images.githubusercontent.com/8883368/76711970-5466aa80-673a-11ea-9e04-66b09d9a45e6.png)

Malayalam currently does not have a consistent hyphenation procedure to apply for `hyphens`, so leaving that out
